### PR TITLE
lightgbm 4.5.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/73950a5
+  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/8d8835a

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/73950a5

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/940162d
+  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/8b87510

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/8b87510

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/8d8835a
+  - https://staging.continuum.io/prefect/fs/scikit-build-core-feedstock/pr3/940162d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lightgbm" %}
-{% set version = "4.3.0" %}
+{% set version = "4.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 006f5784a9bcee43e5a7e943dc4f02de1ba2ee7a7af1ee5f190d383f3b6c9ebe
+  sha256: 9e8a7640911481134e60987d5d1e1cd157f430c3b4b38de8d36fc55c302bc299
 
 build:
   number: 0
@@ -30,7 +30,7 @@ requirements:
     # By default, mkl variants are picked. By picking the variant that uses openblas rather 
     # than mkl, intel-openmp will not be pulled in and so you will not have llvm-openmp / intel-openmp conflict. 
     - blas=*=openblas  # [osx and x86_64]
-    - scikit-build-core >=0.4.4
+    - scikit-build-core >=0.9.3
     - python
     - pip
     - llvm-openmp      # [osx]
@@ -39,8 +39,9 @@ requirements:
     - blas=*=openblas  # [osx and x86_64]
     - python
     - dataclasses      # [py<37]
-    - numpy
+    - numpy >=1.17.0
     - scipy
+    - typing_extensions
   run_constrained:
     - cffi >=1.15.1
     - dask >=2.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,12 +6,16 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9e8a7640911481134e60987d5d1e1cd157f430c3b4b38de8d36fc55c302bc299
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 9e8a7640911481134e60987d5d1e1cd157f430c3b4b38de8d36fc55c302bc299
+  - url: https://github.com/microsoft/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: 2633afd64f4f28c5563cb64e96adf8aa6fae58af11b13345166392fb05e56215
+    folder: tests
 
 build:
   number: 0
   skip: true  # [py<36]
+  script: ls
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Visual Studio 16 2019"  # [win]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Ninja" # [unix]
   missing_dso_whitelist:  # [s390x or osx]
@@ -50,13 +54,27 @@ requirements:
     - scikit-learn !=0.22.0
 
 test:
+  source_files:
+    - tests
   imports:
     - lightgbm
   requires:
     - pip
+    - matplotlib-base
+    - pytest
+    - cloudpickle
+    - psutil
+    # arrow
+    - pyarrow
+    - cffi
+    # panda
+    - pandas
+    # scikit-learn
     - scikit-learn
+
   commands:
     - pip check
+    - pytest -vv .
 
 about:
   home: https://github.com/Microsoft/LightGBM

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.18
+      # We currently don't have ninja 1.11, which upstream specifies. 
+      # However, this feedstock builds and passes tests with v1.10.2
     - ninja >=1.10.2  # [unix]
   host:
     # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy) 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,7 +77,7 @@ test:
     - pip check
     # skipping tests on s390x due to the accuracy required for computational tests.
     - pytest -vv .  # [not s390x]
-    - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs or test_contribs_sparse_multiclass or test_quantized_training)"  # [s390x]
+    - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs or test_contribs_sparse_multiclass or test_quantized_training or test_contribs_sparse)"  # [s390x]
 
 about:
   home: https://github.com/Microsoft/LightGBM

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lightgbm" %}
-{% set version = "4.4.0" %}
+{% set version = "4.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,14 +7,14 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 9e8a7640911481134e60987d5d1e1cd157f430c3b4b38de8d36fc55c302bc299
+    sha256: e1cd7baf0318d4e308a26575a63a4635f08df866ad3622a9d8e3d71d9637a1ba
   - url: https://github.com/microsoft/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 2633afd64f4f28c5563cb64e96adf8aa6fae58af11b13345166392fb05e56215
+    sha256: cc72ae1f979935e11243c93bacefe34144a4fcf3dc304b2a53d99ea408fe8976
     folder: tests
 
 build:
   number: 0
-  skip: true  # [py<36]
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Visual Studio 16 2019"  # [win]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Ninja" # [unix]
   missing_dso_whitelist:  # [s390x or osx]
@@ -34,14 +34,14 @@ requirements:
     # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64. 
     # By default, mkl variants are picked. By picking the variant that uses openblas rather 
     # than mkl, intel-openmp will not be pulled in and so you will not have llvm-openmp / intel-openmp conflict. 
-    - blas=*=openblas  # [osx and x86_64]
+    - blas =*=openblas  # [osx and x86_64]
     - scikit-build-core >=0.9.3
     - python
     - pip
     - llvm-openmp      # [osx]
   run:
     - _openmp_mutex    # [linux]
-    - blas=*=openblas  # [osx and x86_64]
+    - blas =*=openblas  # [osx and x86_64]
     - python
     - dataclasses      # [py<37]
     - numpy >=1.17.0
@@ -65,6 +65,7 @@ test:
     - pytest
     - cloudpickle
     - psutil
+    - joblib >=1.3.2
     # arrow
     - pyarrow
     - cffi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.18
-    # we currently don't have ninja 1.11 but it's building and passing tests
-    - ninja >=1.10.2
+    - ninja >=1.10.2  # [unix]
   host:
     # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy) 
     # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64. 
@@ -73,7 +72,7 @@ test:
     - scikit-learn
   commands:
     - pip check
-    # skipping tests for s390x due to assertion error: Not equal to tolerance rtol=1e-07, atol=0
+    # skipping tests on s390x due to the accuracy required for computational tests.
     - pytest -vv .  # [not s390x]
     - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs or test_contribs_sparse_multiclass or test_quantized_training)"  # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ source:
 build:
   number: 0
   skip: true  # [py<36]
-  script: ls
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Visual Studio 16 2019"  # [win]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Ccmake.define.CMAKE_GENERATOR="Ninja" # [unix]
   missing_dso_whitelist:  # [s390x or osx]
@@ -26,8 +25,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - cmake >=3.8
-    - ninja
+    - cmake >=3.18
+    - ninja >= 1.11
   host:
     # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy) 
     # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64. 
@@ -71,7 +70,6 @@ test:
     - pandas
     # scikit-learn
     - scikit-learn
-
   commands:
     - pip check
     - pytest -vv .  # [not s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,7 +75,7 @@ test:
   commands:
     - pip check
     - pytest -vv .  # [not s390x]
-    - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs ortest_contribs_sparse_multiclass or test_quantized_training)"  # [s390x]
+    - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs or test_contribs_sparse_multiclass or test_quantized_training)"  # [s390x]
 
 about:
   home: https://github.com/Microsoft/LightGBM

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.18
-    - ninja >= 1.11
+    # we currently don't have ninja 1.11 but it's building and passing tests
+    - ninja >=1.10.2
   host:
     # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy) 
     # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64. 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,7 +74,8 @@ test:
 
   commands:
     - pip check
-    - pytest -vv .
+    - pytest -vv .  # [not s390x]
+    - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs ortest_contribs_sparse_multiclass or test_quantized_training)"  # [s390x]
 
 about:
   home: https://github.com/Microsoft/LightGBM

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,6 +73,7 @@ test:
     - scikit-learn
   commands:
     - pip check
+    # skipping tests for s390x due to assertion error: Not equal to tolerance rtol=1e-07, atol=0
     - pytest -vv .  # [not s390x]
     - pytest -vv -k "not (test_categorical_handle or test_categorical_handle_na or test_categorical_non_zero_inputs or test_contribs_sparse_multiclass or test_quantized_training)"  # [s390x]
 


### PR DESCRIPTION
lightgbm 4.5.0 

**Destination channel:** Defaults

### Links

- [PKG-5351]
- dev_url:        https://github.com/microsoft/LightGBM/tree/v4.4.0
- conda_forge:    https://github.com/conda-forge/lightgbm-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/lightgbm/4.4.0
- pypi inspector: https://inspector.pypi.io/project/lightgbm/4.4.0
- Related PRs: Requires: https://github.com/AnacondaRecipes/scikit-build-core-feedstock/pull/3
- Upstream diff: https://github.com/microsoft/LightGBM/compare/v4.3.0...v4.4.0

### Explanation of changes:

- Added and updated dependencies.
- Kept ninja at version >=1.10.2, as it's already building and passing tests. We don't currently have the required version >=1.11.1 specified by upstream (>=1.11).
- Added tests to recipe
- Skipped some tests for s390x due to assertion errors: "Not equal to tolerance rtol=1e-07, atol=0."


[PKG-5351]: https://anaconda.atlassian.net/browse/PKG-5351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ