### PR TITLE
lightgbm v4.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lightgbm" %}
-{% set version = "4.5.0" %}
+{% set version = "4.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,9 +7,9 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: e1cd7baf0318d4e308a26575a63a4635f08df866ad3622a9d8e3d71d9637a1ba
+    sha256: cb1c59720eb569389c0ba74d14f52351b573af489f230032a1c9f314f8bab7fe
   - url: https://github.com/microsoft/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: cc72ae1f979935e11243c93bacefe34144a4fcf3dc304b2a53d99ea408fe8976
+    sha256: 71d2c25855f10e82da8cb8b0c42bdf0da56e5556ff50a93b31c0592b8932eda3
     folder: tests
 
 build:
@@ -26,14 +26,14 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.18
-      # We currently don't have ninja 1.11, which upstream specifies. 
+      # We currently don't have ninja 1.11, which upstream specifies.
       # However, this feedstock builds and passes tests with v1.10.2
     - ninja >=1.10.2  # [unix]
   host:
-    # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy) 
-    # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64. 
-    # By default, mkl variants are picked. By picking the variant that uses openblas rather 
-    # than mkl, intel-openmp will not be pulled in and so you will not have llvm-openmp / intel-openmp conflict. 
+    # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy)
+    # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64.
+    # By default, mkl variants are picked. By picking the variant that uses openblas rather
+    # than mkl, intel-openmp will not be pulled in and so you will not have llvm-openmp / intel-openmp conflict.
     - blas =*=openblas  # [osx and x86_64]
     - scikit-build-core >=0.9.3
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - dask >=2.0.0
     - pandas >=0.24.0
     - pyarrow >=6.0.1
-    - scikit-learn !=0.22.0
+    - scikit-learn >=0.24.2
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,14 +28,14 @@ requirements:
     - cmake >=3.18
       # We currently don't have ninja 1.11, which upstream specifies.
       # However, this feedstock builds and passes tests with v1.10.2
-    - ninja >=1.10.2  # [unix]
+    - ninja >=1.12.1  # [unix]
   host:
     # This basically forces to pick scipy (and any other suitable packages in the chain, like numpy)
     # that was built with openblas rather than mkl. Openblas typically pairs with llvm-openmp and mkl with intel-openmp on osx-64.
     # By default, mkl variants are picked. By picking the variant that uses openblas rather
     # than mkl, intel-openmp will not be pulled in and so you will not have llvm-openmp / intel-openmp conflict.
     - blas =*=openblas  # [osx and x86_64]
-    - scikit-build-core >=0.9.3
+    - scikit-build-core >=0.10.1
     - python
     - pip
     - llvm-openmp      # [osx]
@@ -43,10 +43,8 @@ requirements:
     - _openmp_mutex    # [linux]
     - blas =*=openblas  # [osx and x86_64]
     - python
-    - dataclasses      # [py<37]
     - numpy >=1.17.0
     - scipy
-    - typing_extensions
   run_constrained:
     - cffi >=1.15.1
     - dask >=2.0.0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7059](https://anaconda.atlassian.net/browse/PKG-7059)
- [Upstream repository](https://github.com/microsoft/LightGBM/tree/v4.6.0)
- [Upstream changelog/diff](https://github.com/microsoft/LightGBM/releases)

### Explanation of changes:

- Update version number and sha256


[PKG-7059]: https://anaconda.atlassian.net/browse/PKG-7059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ