### PR TITLE
Explicitly include openmp

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - build

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - build

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,13 +1,3 @@
-# Repeated to match gpu_variant zip_keys (none, cuda, cuda)
-c_compiler:                      # [win]
-  - vs2022                       # [win]
-  - vs2022                       # [win]
-  - vs2022                       # [win]
-cxx_compiler:                    # [win]
-  - vs2022                       # [win]
-  - vs2022                       # [win]
-  - vs2022                       # [win]
-
 gpu_variant:
   - none
   - cuda                         # [linux or win]
@@ -19,7 +9,7 @@ cuda_compiler:                   # [linux or win]
 cuda_compiler_version:           # [linux or win]
   - none                         # [linux or win]
   - 12.9                         # [linux or win]
-  - 13.1                         # [linux or win]
+  - 13.0                         # [linux or win]
 
 # Only zip on linux/win where cuda_compiler_version exists;
 # on osx gpu_variant is always 'none' (single value, no zip needed).
@@ -27,5 +17,3 @@ zip_keys:
   -                              # [linux or win]
     - gpu_variant                # [linux or win]
     - cuda_compiler_version      # [linux or win]
-    - c_compiler                 # [win]
-    - cxx_compiler               # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "lightgbm" %}
 {% set version = "4.6.0" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 package:
   name: {{ name|lower }}
@@ -55,10 +55,13 @@ requirements:
     - python
     - pip
     - llvm-openmp                                          # [osx]
+    - libgomp          # [linux]
+    - vcomp14          # [win and x86_64]
     - cuda-version {{ cuda_compiler_version }}              # [gpu_variant == "cuda"]
     - cuda-cudart-dev                                      # [gpu_variant == "cuda"]
   run:
-    - _openmp_mutex    # [linux]
+    - libgomp          # [linux]
+    - vcomp14          # [win and x86_64]
     - blas =*=openblas  # [osx and x86_64]
     - python
     - numpy >=1.17.0


### PR DESCRIPTION
lightgbm openmp rebuild

**Destination channel:** defaults

### Links

- [PKG-14730](https://anaconda.atlassian.net/browse/PKG-14730) 


### Explanation of changes:

- Cleanup cbc
- Build for CUDA 13.0 instead of 13.1 as the team has decided
- Bump build number
- Explicitly add the openmp implementation being used. 

## Note
The Github UI didn't update, the graph is green: https://package-build.anaconda.com/v1/graph/620af266-3e36-4f77-a58a-6aafe107476a



[OpenMP usage Audit](https://docs.google.com/spreadsheets/d/1Pln3E1WKlhasfR5NNyT9juhXrcM_63bQpAZRHDjNHtc/edit?usp=sharing)

[PKG-14730]: https://anaconda.atlassian.net/browse/PKG-14730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ